### PR TITLE
Changed dialog text and settings page destination

### DIFF
--- a/lib/src/features/positioner/widgets/ask_enable_position_service_dialog.dart
+++ b/lib/src/features/positioner/widgets/ask_enable_position_service_dialog.dart
@@ -13,13 +13,16 @@ class AskEnablePositionServiceDialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final OpenPositionServicePage openPositionServicePage = GetIt.I();
+
     return BlocListener<PositionBloc, PositionBlocState>(
       listenWhen: (prev, curr) =>
           prev.isServiceEnabled != curr.isServiceEnabled && curr.isServiceEnabled,
       // Auto closing of the dialog when the service has been enabled
       listener: (context, state) => Navigator.of(context).pop(true),
-      child: const AskOpenAppSettingsPageDialog(
-        title: Text('Enable the GeoLocalization service'),
+      child: AskOpenSettingsPageDialog(
+        openSettings: openPositionServicePage,
+        title: const Text('Please turn on the device position'),
       ),
     );
   }

--- a/lib/src/features/positioner/widgets/ask_enable_position_service_dialog.dart
+++ b/lib/src/features/positioner/widgets/ask_enable_position_service_dialog.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:get_it/get_it.dart';
 import 'package:kuama_flutter/src/_utils/lg.dart';
-import 'package:kuama_flutter/src/features/app_pages/use_cases/open_settings_app_page.dart';
 import 'package:kuama_flutter/src/features/positioner/bloc/position_bloc.dart';
+import 'package:kuama_flutter/src/features/positioner/usecases/open_position_service_page.dart';
 import 'package:kuama_flutter/src/shared/feature_structure/use_case.dart';
 import 'package:kuama_flutter/src/shared/widgets/change_handler.dart';
 import 'package:kuama_flutter/src/shared/widgets/dialogs/app_settings_dialog.dart';
@@ -52,7 +52,7 @@ class OrderEnablePositionServiceDialog extends StatelessWidget {
         child: WillPopScope(
           onWillPop: () async => false,
           child: AlertDialog(
-            title: title ?? const Text('Position service required'),
+            title: title ?? const Text('Please turn on the device position'),
             actions: [
               TextButton(
                 onPressed: () => Navigator.of(context).pop(false),
@@ -60,11 +60,11 @@ class OrderEnablePositionServiceDialog extends StatelessWidget {
               ),
               ElevatedButton(
                 onPressed: () async {
-                  final result = await GetIt.I<OpenSettingsAppPage>().call(NoParams());
+                  final result = await GetIt.I<OpenPositionServicePage>().call(NoParams());
                   result.fold((failure) {
-                    lg.e('Open Settings app page failed!', failure);
+                    lg.e('Open Location Settings page failed!', failure);
                   }, (isOpened) {
-                    if (!isOpened) lg.e('Open Settings app page failed!');
+                    if (!isOpened) lg.e('Open Location Settings page failed!');
                   });
                 },
                 child: settingsLabel ?? const Text('Open Settings'),

--- a/lib/src/features/positioner/widgets/ask_enable_position_service_dialog.dart
+++ b/lib/src/features/positioner/widgets/ask_enable_position_service_dialog.dart
@@ -13,15 +13,13 @@ class AskEnablePositionServiceDialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final OpenPositionServicePage openPositionServicePage = GetIt.I();
-
     return BlocListener<PositionBloc, PositionBlocState>(
       listenWhen: (prev, curr) =>
           prev.isServiceEnabled != curr.isServiceEnabled && curr.isServiceEnabled,
       // Auto closing of the dialog when the service has been enabled
       listener: (context, state) => Navigator.of(context).pop(true),
       child: AskOpenSettingsPageDialog(
-        openSettings: openPositionServicePage,
+        openSettings: GetIt.I<OpenPositionServicePage>(),
         title: const Text('Please turn on the device position'),
       ),
     );

--- a/lib/src/shared/widgets/dialogs/app_settings_dialog.dart
+++ b/lib/src/shared/widgets/dialogs/app_settings_dialog.dart
@@ -1,34 +1,38 @@
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:kuama_flutter/src/_utils/lg.dart';
-import 'package:kuama_flutter/src/features/app_pages/use_cases/open_settings_app_page.dart';
+import 'package:kuama_flutter/src/features/positioner/usecases/open_position_service_page.dart';
 import 'package:kuama_flutter/src/shared/feature_structure/use_case.dart';
 
-class AskOpenAppSettingsPageDialog extends StatelessWidget {
+class AskOpenSettingsPageDialog extends StatelessWidget {
+  final UseCase<NoParams, bool>? openSettings;
   final Widget? title;
   final Widget? cancelLabel;
   final Widget? settingsLabel;
 
-  const AskOpenAppSettingsPageDialog({
+  const AskOpenSettingsPageDialog({
     Key? key,
+    this.openSettings,
     this.title,
     this.cancelLabel,
     this.settingsLabel,
   }) : super(key: key);
 
   void openSettingsPage() async {
-    final res = await GetIt.I<OpenSettingsAppPage>().call(NoParams());
+    final res = openSettings != null
+        ? await openSettings!.call(NoParams())
+        : await GetIt.I<OpenPositionServicePage>().call(NoParams());
     res.fold((failure) {
-      lg.e('The app settings page could not be opened', failure);
+      lg.e('The settings page could not be opened', failure);
     }, (wasOpened) {
-      if (!wasOpened) lg.e('The app settings page could not be opened');
+      if (!wasOpened) lg.e('The settings page could not be opened');
     });
   }
 
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      title: title ?? const Text('Open app settings'),
+      title: title ?? const Text('Open settings'),
       actions: [
         TextButton(
           onPressed: () => Navigator.of(context).pop(false),
@@ -36,7 +40,7 @@ class AskOpenAppSettingsPageDialog extends StatelessWidget {
         ),
         ElevatedButton(
           onPressed: openSettingsPage,
-          child: settingsLabel ?? const Text('Settings'),
+          child: settingsLabel ?? const Text('Open'),
         ),
       ],
     );

--- a/lib/src/shared/widgets/dialogs/app_settings_dialog.dart
+++ b/lib/src/shared/widgets/dialogs/app_settings_dialog.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:kuama_flutter/src/_utils/lg.dart';
-import 'package:kuama_flutter/src/features/positioner/usecases/open_position_service_page.dart';
+import 'package:kuama_flutter/src/features/app_pages/use_cases/open_settings_app_page.dart';
 import 'package:kuama_flutter/src/shared/feature_structure/use_case.dart';
 
 class AskOpenSettingsPageDialog extends StatelessWidget {
@@ -19,9 +19,7 @@ class AskOpenSettingsPageDialog extends StatelessWidget {
   }) : super(key: key);
 
   void openSettingsPage() async {
-    final res = openSettings != null
-        ? await openSettings!.call(NoParams())
-        : await GetIt.I<OpenPositionServicePage>().call(NoParams());
+    final res = await (openSettings ?? GetIt.I<OpenSettingsAppPage>()).call(NoParams());
     res.fold((failure) {
       lg.e('The settings page could not be opened', failure);
     }, (wasOpened) {


### PR DESCRIPTION
Related to https://github.com/Kuama-IT/My-First-Alert/issues/176
 - Changed dialog text of the `ask_enable_position_service_dialog`
 - Changed `open settings` dialog button action to send user to device location settings instead of app settings