### PR TITLE
fix: `Continue` and `Cancel` button's strings in permission dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.2.2
+> 2023-10-19
+- fix: `Continue` and `Cancel` button's strings in permission dialog 
+
 ## 0.2.1
 > 2023-08-11
 - feat: update Dio version

--- a/lib/src/features/permissions/widgets/ask_allow_permission_dialog.dart
+++ b/lib/src/features/permissions/widgets/ask_allow_permission_dialog.dart
@@ -62,11 +62,11 @@ class ConfirmAllowPermissionsDialog<TPermissionBloc extends PermissionBloc>
             actions: [
               TextButton(
                 onPressed: state.canRequest ? () => permissionBloc.confirmRequest(false) : null,
-                child: notAllowLabel ?? const Text('Not allow'),
+                child: notAllowLabel ?? const Text('Cancel'),
               ),
               ElevatedButton(
                 onPressed: state.canRequest ? () => permissionBloc.confirmRequest(true) : null,
-                child: allowLabel ?? const Text('Allow'),
+                child: allowLabel ?? const Text('Continue'),
               ),
             ],
           ),
@@ -130,7 +130,7 @@ class OrderAllowPermissionDialog<TPermissionBloc extends PermissionBloc> extends
                 onPressed: _delegateMainButtonPress(context, permissionBloc, state),
                 child: state.isPermanentlyDenied
                     ? settingsLabel ?? const Text('Settings')
-                    : allowLabel ?? const Text('Allow'),
+                    : allowLabel ?? const Text('Continue'),
               ),
             ],
           );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kuama_flutter
 description: A new Flutter project.
-version: 0.2.1
+version: 0.2.2
 publish_to: 'none'
 
 environment:


### PR DESCRIPTION
needs for be consistent with apple privacy https://developer.apple.com/design/human-interface-guidelines/privacy